### PR TITLE
Fix release workflow tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,26 @@ jobs:
           fetch-depth: 0
       - name: Generate Changelog
         run: .github/release_message.sh > release_message.md
+      - name: Get current version
+        id: version
+        run: |
+          VERSION=$(grep -oP "__version__ = '\K[^']+" drf_spectacular/__init__.py)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+      - name: Create tag if needed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if git rev-parse "refs/tags/${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+            echo "Tag ${{ steps.version.outputs.version }} already exists"
+          else
+            git tag "${{ steps.version.outputs.version }}"
+            git push origin "${{ steps.version.outputs.version }}"
+          fi
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
           body_path: release_message.md
+          tag_name: ${{ steps.version.outputs.version }}
 
   deploy:
     needs: release


### PR DESCRIPTION
## Summary
- auto-create git tags from package version before running GitHub release

## Testing
- `python runtests.py --nolint`

------
https://chatgpt.com/codex/tasks/task_e_68524baa1cf88326a2a1577fc80da276