### PR TITLE
Update documentation site URLs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1071,7 +1071,7 @@ Breaking changes:
 
 Breaking changes:
 
-- Enum naming conflicts are now resolved explicitly. `how to resolve conflicts <https://drf-spectacular.readthedocs.io/en/latest/faq.html#i-get-warnings-regarding-my-enum-or-my-enum-names-have-a-weird-suffix>`_
+- Enum naming conflicts are now resolved explicitly. `how to resolve conflicts <https://evo-drf-spectacular.readthedocs.io/en/latest/faq.html#i-get-warnings-regarding-my-enum-or-my-enum-names-have-a-weird-suffix>`_
 - Choice fields may be rendered slightly different
 - Swagger UI and Redoc views now honor versioned requests
 - Contrib package code moved. each package has its own file now

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -60,6 +60,6 @@ With that out of the way, we hope to hear from you soon.
 
 .. _code coverage: https://app.codecov.io/gh/tfranzel/drf-spectacular
 .. _test suite: https://github.com/tfranzel/drf-spectacular/tree/master/tests
-.. _blueprints: https://drf-spectacular.readthedocs.io/en/latest/blueprints.html
+.. _blueprints: https://evo-drf-spectacular.readthedocs.io/en/latest/blueprints.html
 .. _early feedback: https://github.com/tfranzel/drf-spectacular/issues
 .. _test_regressions.py: https://github.com/tfranzel/drf-spectacular/blob/master/tests/test_regressions.py

--- a/README.rst
+++ b/README.rst
@@ -17,14 +17,14 @@ which is/was lacking all of the below listed features.
 
 Features
     - Serializers modelled as components. (arbitrary nesting and recursion supported)
-    - `@extend_schema <https://drf-spectacular.readthedocs.io/en/latest/drf_spectacular.html#drf_spectacular.utils.extend_schema>`_ decorator for customization of APIView, Viewsets, function-based views, and ``@action``
+    - `@extend_schema <https://evo-drf-spectacular.readthedocs.io/en/latest/drf_spectacular.html#drf_spectacular.utils.extend_schema>`_ decorator for customization of APIView, Viewsets, function-based views, and ``@action``
         - additional parameters
         - request/response serializer override (with status codes)
         - polymorphic responses either manually with ``PolymorphicProxySerializer`` helper or via ``rest_polymorphic``'s PolymorphicSerializer)
         - ... and more customization options
     - Authentication support (DRF natives included, easily extendable)
     - Custom serializer class support (easily extendable)
-    - `SerializerMethodField() <https://drf-spectacular.readthedocs.io/en/latest/customization.html#step-3-extend-schema-field-and-type-hints>`_ type via type hinting or ``@extend_schema_field``
+    - `SerializerMethodField() <https://evo-drf-spectacular.readthedocs.io/en/latest/customization.html#step-3-extend-schema-field-and-type-hints>`_ type via type hinting or ``@extend_schema_field``
     - i18n support
     - Tags extraction
     - Request/response/parameter examples
@@ -51,7 +51,7 @@ Features
         - `Pydantic (>=2.0) <https://github.com/pydantic/pydantic>`_
 
 
-For more information visit the `documentation <https://drf-spectacular.readthedocs.io/>`_.
+For more information visit the `documentation <https://evo-drf-spectacular.readthedocs.io/>`_.
 
 License
 -------
@@ -93,7 +93,7 @@ and finally register our spectacular AutoSchema with DRF.
         'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
     }
 
-drf-spectacular ships with sane `default settings <https://drf-spectacular.readthedocs.io/en/latest/settings.html>`_
+drf-spectacular ships with sane `default settings <https://evo-drf-spectacular.readthedocs.io/en/latest/settings.html>`_
 that should work reasonably well out of the box. It is not necessary to
 specify any settings, but we recommend to specify at least some metadata.
 
@@ -180,7 +180,7 @@ Usage
 
 *drf-spectacular* works pretty well out of the box. You might also want to set some metadata for your API.
 Just create a ``SPECTACULAR_SETTINGS`` dictionary in your ``settings.py`` and override the defaults.
-Have a look at the `available settings <https://drf-spectacular.readthedocs.io/en/latest/settings.html>`_.
+Have a look at the `available settings <https://evo-drf-spectacular.readthedocs.io/en/latest/settings.html>`_.
 
 The toy examples do not cover your cases? No problem, you can heavily customize how your schema will be rendered.
 
@@ -264,7 +264,7 @@ More customization
 ^^^^^^^^^^^^^^^^^^
 
 Still not satisfied? You want more! We still got you covered.
-Visit `customization <https://drf-spectacular.readthedocs.io/en/latest/customization.html>`_ for more information.
+Visit `customization <https://evo-drf-spectacular.readthedocs.io/en/latest/customization.html>`_ for more information.
 
 
 Testing
@@ -304,6 +304,6 @@ globally, and then simply run:
 .. |codecov| image:: https://codecov.io/gh/tfranzel/drf-spectacular/branch/master/graph/badge.svg
    :target: https://codecov.io/gh/tfranzel/drf-spectacular
 .. |docs| image:: https://readthedocs.org/projects/drf-spectacular/badge/
-   :target: https://drf-spectacular.readthedocs.io/
+   :target: https://evo-drf-spectacular.readthedocs.io/
 .. |pypi-dl| image:: https://img.shields.io/pypi/dm/drf-spectacular
    :target: https://pypi.org/project/drf-spectacular/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,7 +50,7 @@ default_role = 'default-role-error'
 
 linkcheck_allowed_redirects = {
     r"^https://tox\.wiki/$": r"https://tox\.wiki/en/latest/$",
-    r"^https://drf-spectacular\.readthedocs\.io/$": r"https://drf-spectacular\.readthedocs\.io/en/latest/$",
+    r"^https://evo-drf-spectacular.readthedocs.io/$": r"https://evo-drf-spectacular.readthedocs.io/en/latest/$",
     r"^https://docs\.djangoproject\.com/en/stable/": r"^https://docs\.djangoproject\.com/en/\d+\.\d+/",
     r"^https://github\.com/tfranzel/drf-spectacular/issues/\d+": r"https://github\.com/tfranzel/drf-spectacular/pull/\d+",
 }

--- a/setup.py
+++ b/setup.py
@@ -108,6 +108,6 @@ setup(
     ],
     project_urls={
         'Source': 'https://github.com/maycuatroi/evo-drf-spectacular',
-        'Documentation': 'https://drf-spectacular.readthedocs.io',
+        'Documentation': 'https://evo-drf-spectacular.readthedocs.io',
     },
 )


### PR DESCRIPTION
## Summary
- update project links to https://evo-drf-spectacular.readthedocs.io

## Testing
- `python runtests.py --nolint`


------
https://chatgpt.com/codex/tasks/task_e_6852512321708326a752a325b49c00ac